### PR TITLE
Fix pip install from source by adding MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include requirements.txt


### PR DESCRIPTION
Installing the package from source tarball fails as the setup.py tries to open two files that are not part of the tarball.

With a MANIFEST.in to include README.md and requirements.txt as needed by
setup.py, everything is well.

Before this fix:
```
arnold@xingu:~/programme$ pip install dist/aiohue-1.3.0.tar.gz
Processing ./dist/aiohue-1.3.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-fop5pmr6/aiohue/setup.py", line 4, in <module>
        long_description = open('README.md').read()
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-fop5pmr6/aiohue/
You are using pip version 9.0.1, however version 9.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

With this branch:

```
pip install dist/aiohue-1.3.0.tar.gz 
Processing ./dist/aiohue-1.3.0.tar.gz
Requirement already satisfied: aiohttp in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohue==1.3.0)
Requirement already satisfied: chardet<4.0,>=2.0 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohttp->aiohue==1.3.0)
Requirement already satisfied: idna-ssl>=1.0 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohttp->aiohue==1.3.0)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohttp->aiohue==1.3.0)
Requirement already satisfied: multidict<5.0,>=4.0 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohttp->aiohue==1.3.0)
Requirement already satisfied: attrs>=17.3.0 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohttp->aiohue==1.3.0)
Requirement already satisfied: async-timeout<3.0,>=1.2 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from aiohttp->aiohue==1.3.0)
Requirement already satisfied: idna>=2.0 in /home/arnold/.pyenv/versions/3.6.3/envs/aiohue_test/lib/python3.6/site-packages (from idna-ssl>=1.0->aiohttp->aiohue==1.3.0)
Installing collected packages: aiohue
  Running setup.py install for aiohue ... done
Successfully installed aiohue-1.3.0
You are using pip version 9.0.1, however version 9.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```