### PR TITLE
Add support for Hue sensors

### DIFF
--- a/aiohue/bridge.py
+++ b/aiohue/bridge.py
@@ -6,6 +6,7 @@ from .config import Config
 from .groups import Groups
 from .lights import Lights
 from .scenes import Scenes
+from .sensors import Sensors
 from .errors import raise_error, ResponseError, RequestError
 
 
@@ -22,11 +23,11 @@ class Bridge:
         self.groups = None
         self.lights = None
         self.scenes = None
+        self.sensors = None
 
         # self.capabilities = None
         # self.rules = None
         # self.schedules = None
-        # self.sensors = None
 
     async def create_user(self, device_type):
         """Create a user.
@@ -46,6 +47,7 @@ class Bridge:
         self.groups = Groups(result['groups'], self.request)
         self.lights = Lights(result['lights'], self.request)
         self.scenes = Scenes(result['scenes'], self.request)
+        self.sensors = Sensors(result['sensors'], self.request)
 
     async def request(self, method, path, json=None, auth=True):
         """Make a request to the API."""

--- a/aiohue/sensors.py
+++ b/aiohue/sensors.py
@@ -1,0 +1,55 @@
+from .api import APIItems
+
+
+class Sensors(APIItems):
+    """Represents Hue Sensors.
+
+    https://developers.meethue.com/documentation/sensors-api
+    """
+
+    def __init__(self, raw, request):
+        super().__init__(raw, request, 'sensors', Sensor)
+
+
+class Sensor:
+    """Represents a Hue sensor."""
+    def __init__(self, id, raw, request):
+        self.id = id
+        self.raw = raw
+        self._request = request
+
+    @property
+    def name(self):
+        return self.raw['name']
+
+    @property
+    def type(self):
+        return self.raw['type']
+
+    @property
+    def modelid(self):
+        return self.raw['modelid']
+
+    @property
+    def manufacturername(self):
+        return self.raw['manufacturername']
+
+    @property
+    def productname(self):
+        return self.raw['productname']
+
+    @property
+    def uniqueid(self):
+        return self.raw['uniqueid']
+
+    @property
+    def swversion(self):
+        return self.raw['swversion']
+
+    @property
+    def state(self):
+        return self.raw['state']
+
+    @property
+    def config(self):
+        return self.raw['config']

--- a/example.py
+++ b/example.py
@@ -50,4 +50,10 @@ async def run(websession):
         scene = bridge.scenes[id]
         print(scene.name)
 
+    print()
+    print('Sensors:')
+    for id in bridge.sensors:
+        sensor = bridge.sensors[id]
+        print(sensor.name)
+
 asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
Add support for Hue sensors to aiohue as preliminary step in starting to add Hue sensor support to Home Assistant.

Properties in the Sensor class correspond to the Hue Sensors API documentation, all top level attributes under "3. General Sensor Resource": https://developers.meethue.com/documentation/supported-sensors.

One point for your comment - not all sensors have all top-level attributes, so instead of returning `self.raw['attributename']` should we return `self.raw.get('attributename')` so that nonexistent attributes return "None" instead of raising a KeyError?