### PR TITLE
add get gamut information

### DIFF
--- a/aiohue/lights.py
+++ b/aiohue/lights.py
@@ -1,4 +1,22 @@
 from .api import APIItems
+import attr
+
+
+@attr.s()
+class XYPoint:
+    """Represents a CIE 1931 XY coordinate pair."""
+
+    x = attr.ib(type=float)
+    y = attr.ib(type=float)
+
+
+@attr.s()
+class GamutType:
+    """Represents the Gamut of a light."""
+
+    red = attr.ib(type=XYPoint)
+    green = attr.ib(type=XYPoint)
+    blue = attr.ib(type=XYPoint)
 
 
 class Lights(APIItems):
@@ -51,6 +69,29 @@ class Light:
     def swversion(self):
         """Software version of the light."""
         return self.raw['swversion']
+
+    @property
+    def controlcapabilities(self):
+        """Capabilities that the light has to control it."""
+        return self.raw.get('capabilities', {}).get('control', {})
+
+    @property
+    def colorgamuttype(self):
+        """The color gamut type of the light."""
+        light_spec = self.controlcapabilities()
+        return light_spec.get('colorgamuttype', 'None')
+
+    @property
+    def colorgamut(self):
+        """The color gamut information of the light."""
+        try:
+            light_spec = self.controlcapabilities()
+            gtup = tuple([XYPoint(*x) for x in light_spec['colorgamut']])
+            color_gamut = GamutType(*gtup)
+        except KeyError:
+            color_gamut = None
+
+        return color_gamut
 
     async def set_state(self, on=None, bri=None, hue=None, sat=None, xy=None,
                         ct=None, alert=None, effect=None, transitiontime=None,

--- a/aiohue/lights.py
+++ b/aiohue/lights.py
@@ -1,22 +1,13 @@
 from .api import APIItems
-import attr
+from collections import namedtuple
 
 
-@attr.s()
-class XYPoint:
-    """Represents a CIE 1931 XY coordinate pair."""
-
-    x = attr.ib(type=float)
-    y = attr.ib(type=float)
+# Represents a CIE 1931 XY coordinate pair.
+XYPoint = namedtuple('XYPoint', ['x', 'y'])
 
 
-@attr.s()
-class GamutType:
-    """Represents the Gamut of a light."""
-
-    red = attr.ib(type=XYPoint)
-    green = attr.ib(type=XYPoint)
-    blue = attr.ib(type=XYPoint)
+# Represents the Gamut of a light.
+GamutType = namedtuple('GamutType', ['red', 'green', 'blue'])
 
 
 class Lights(APIItems):

--- a/aiohue/lights.py
+++ b/aiohue/lights.py
@@ -78,14 +78,14 @@ class Light:
     @property
     def colorgamuttype(self):
         """The color gamut type of the light."""
-        light_spec = self.controlcapabilities()
+        light_spec = self.controlcapabilities
         return light_spec.get('colorgamuttype', 'None')
 
     @property
     def colorgamut(self):
         """The color gamut information of the light."""
         try:
-            light_spec = self.controlcapabilities()
+            light_spec = self.controlcapabilities
             gtup = tuple([XYPoint(*x) for x in light_spec['colorgamut']])
             color_gamut = GamutType(*gtup)
         except KeyError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp
+attrs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiohttp
-attrs


### PR DESCRIPTION
This Pull Request is needed for the "Improve Philips Hue color conversion" PR in HomeAssistant:
https://github.com/home-assistant/home-assistant/pull/19123
This adds the capability to get and parse the color gamut information that is supplied by the Hue bridge.
Tested this PR with HomeAssistant and everthing works just fine.