### PR TITLE
Add support for ZLLRelativeRotary sensor

### DIFF
--- a/aiohue/sensors.py
+++ b/aiohue/sensors.py
@@ -17,6 +17,7 @@ TYPE_ZGP_SWITCH = 'ZGPSwitch'
 
 TYPE_ZLL_LIGHTLEVEL = 'ZLLLightLevel'
 TYPE_ZLL_PRESENCE = 'ZLLPresence'
+TYPE_ZLL_ROTARY = 'ZLLRelativeRotary'
 TYPE_ZLL_SWITCH = 'ZLLSwitch'
 TYPE_ZLL_TEMPERATURE = 'ZLLTemperature'
 
@@ -232,6 +233,31 @@ class ZLLPresenceSensor(GenericZLLSensor):
                 'on': on,
                 'sensitivity': sensitivity,
                 'sensitivitymax': sensitivitymax,
+            }.items() if value is not None
+        }
+
+        await self._request('put', 'sensors/{}/config'.format(self.id),
+                            json=data)
+
+
+class ZLLRotarySensor(GenericZLLSensor):
+    @property
+    def rotaryevent(self):
+        return self.raw['state']['rotaryevent']
+
+    @property
+    def expectedrotation(self):
+        return self.raw['state']['expectedrotation']
+
+    @property
+    def expectedeventduration(self):
+        return self.raw['state']['expectedeventduration']
+
+    async def set_config(self, on=None):
+        """Change config of a ZLL Rotary sensor."""
+        data = {
+            key: value for key, value in {
+                'on': on,
             }.items() if value is not None
         }
 
@@ -503,6 +529,8 @@ def create_sensor(id, raw, request):
         return ZLLLightLevelSensor(id, raw, request)
     elif type == TYPE_ZLL_PRESENCE:
         return ZLLPresenceSensor(id, raw, request)
+    elif type == TYPE_ZLL_ROTARY:
+        return ZLLRotarySensor(id, raw, request)
     elif type == TYPE_ZLL_SWITCH:
         return ZLLSwitchSensor(id, raw, request)
     elif type == TYPE_ZLL_TEMPERATURE:

--- a/example.py
+++ b/example.py
@@ -7,7 +7,8 @@ from aiohue.sensors import (TYPE_CLIP_GENERICFLAG, TYPE_CLIP_GENERICSTATUS,
                             TYPE_CLIP_HUMIDITY, TYPE_CLIP_LIGHTLEVEL, TYPE_CLIP_OPENCLOSE,
                             TYPE_CLIP_PRESENCE, TYPE_CLIP_SWITCH, TYPE_CLIP_TEMPERATURE,
                             TYPE_DAYLIGHT, TYPE_ZGP_SWITCH, TYPE_ZLL_LIGHTLEVEL,
-                            TYPE_ZLL_PRESENCE, TYPE_ZLL_SWITCH, TYPE_ZLL_TEMPERATURE)
+                            TYPE_ZLL_PRESENCE, TYPE_ZLL_ROTARY, TYPE_ZLL_SWITCH,
+                            TYPE_ZLL_TEMPERATURE)
 
 from aiohue.discovery import discover_nupnp
 
@@ -61,6 +62,8 @@ async def run(websession):
         sensor = bridge.sensors[id]
         if sensor.type in [TYPE_CLIP_SWITCH, TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH]:
             print('{}: [Button Event]: {}'.format(sensor.name, sensor.buttonevent))
+        elif sensor.type in [TYPE_ZLL_ROTARY]:
+            print('{}: [Rotation Event]: {}'.format(sensor.name, sensor.rotaryevent))
         elif sensor.type in [TYPE_CLIP_TEMPERATURE, TYPE_ZLL_TEMPERATURE]:
             print('{}: [Temperature]: {}'.format(sensor.name, sensor.temperature))
         elif sensor.type in [TYPE_CLIP_PRESENCE, TYPE_ZLL_PRESENCE]:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open('README.md').read()
 
 setup(
     name='aiohue',
-    version='2.0.0',
+    version='2.0.1',
     license='Apache License 2.0',
     url='https://github.com/balloob/aiohue',
     author='Paulus Schoutsen',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open('README.md').read()
 
 setup(
     name='aiohue',
-    version='2.0.1',
+    version='2.1.0',
     license='Apache License 2.0',
     url='https://github.com/balloob/aiohue',
     author='Paulus Schoutsen',


### PR DESCRIPTION
* Add `ZLLRelativeRotary` sensor as a new `ZLLSensor` with `rotaryevent` property instead of `buttonevent`. Correspondence with model id "Z3-1BRL", (Lutron Aurora Rotary)
* Bump minor version to 2.0.1